### PR TITLE
word-tokenization: Lookup definitions & images without punctuation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,9 @@ build:
 	#   catching errors here.
 	${UGLIFYJS} -c -m -o static/build/js/vendor/require.js \
 	    static/build/js/vendor/require.js
+
+update-nltk:
+	@echo Downloading corpus files for nltk library...
+	python -m nltk.downloader punkt
+
+	

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Install the dependencies:
     $ mkvirtualenv languagelearning
     $ pip install -r requirements.txt
 
+Download the corpus data for the nltk library:
+
+    $ make update-nltk
+
 Configuration
 -------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 Django==1.5.1
+PyYAML==3.10
 argparse==1.2.1
 coverage==3.6
 distribute==0.6.35
 httplib2==0.8
 mock==1.0.1
+nltk==2.0.4
 pycaustic==0.0.33
 requests==1.2.0
 stevedore==0.8


### PR DESCRIPTION
Uses nltk tokenization to split words, and then remove punctuation
tokens. Stores clean list of words in `SearchAPIView.words`.
