### PR TITLE
gt-bad-language-pair: Unsupported translations consistency check

### DIFF
--- a/dist/googletranslate.py
+++ b/dist/googletranslate.py
@@ -224,7 +224,7 @@ class GoogleTranslator(object):
         # going to have json, decode it first
         return self._decode_json(content)
 
-    def translate(self, query, target="en", source="", _dirty=False):
+    def translate(self, query, target="en", source=""):
         """
         Translate a query.
 
@@ -237,10 +237,6 @@ class GoogleTranslator(object):
         source : str, optional
             Language of the source text, if known. Will be auto-detected
             if an empty string is passed.
-        dirty : bool
-            This is not intended to be used by users. It is here to avoid
-            infinite recursion if the query returns an error because the
-            language can't be detected.
 
         Returns
         -------
@@ -270,13 +266,6 @@ class GoogleTranslator(object):
         url = self._build_uri("", params)
         content = self._fetch_data(url)
         results = self._decode_json(content)
-
-        if "errors" in results and not _dirty:
-            if results['message'] == 'Bad language pair: {0}':
-                # try to detect language and resubmit query
-                source = self.detect(query)
-                source = source[0]['language']
-                return self.translate(query, target, source, True)
 
         return results
 

--- a/search/views/search.py
+++ b/search/views/search.py
@@ -65,13 +65,22 @@ class SearchAPIView(APIView):
         response = translator.translate(expression, source=self.source, target=self.target)
 
         if u'error' in response:
-            raise ErrorResponse(json.dumps(response[u'error']))
+            # When Google can't translate between language pairs, still detect source & proceed
+            if 'message' in response['error'] and \
+                    response['error']['message'] == 'Bad language pair: {0}':
+                source_response = translator.detect(expression)
+                self.source = source_response['data']['detections'][0][0]['language']
+                # Return the source text to mirror GT's behavior when it can't translate
+                translated_text = self.expression
+            else:
+                raise ErrorResponse(json.dumps(response[u'error']))
         
-        translation = response[u'data'][u'translations'][0]
-        translated_text = translation[u'translatedText']
+        else:
+            translation = response[u'data'][u'translations'][0]
+            translated_text = translation[u'translatedText']
 
-        if not self.source and u'detectedSourceLanguage' in translation:
-            self.source = translation[u'detectedSourceLanguage']
+            if not self.source and u'detectedSourceLanguage' in translation:
+                self.source = translation[u'detectedSourceLanguage']
 
         return translated_text
 


### PR DESCRIPTION
When Google Translate doesn't support translating from one language to another, it returns an error - this behavior differs from what happens when it does support a language pair but can't translate a specific sentence.

In the later, which is the most common scenario, it returns the source expression in the translation result. To make the behavior consistent in both scenarios, and allow the user to still see any definitions/images, mirror the later scenario when a language pair is not supported.

Return the results normally, replacing the language detection normally done by the `translate()` call by a specific call to `detect()` (also from Google Translate).

Note: Also removed the dirty hack the googletranslate library was using in that scenario, since Google Translate will never be able to translate the sentence when the language pair is unsupported.
