### PR TITLE
build-uptodate: Allows `make build` when `build` directory exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: test-client build update-nltk
+
 SHELL := /bin/bash
 NODE ?= $(shell which node)
 NPM ?= $(shell which npm)


### PR DESCRIPTION
If the `build` directory exists, since it has no dependencies that are
more recent, the target is not rebuilt. To force rebuild, make the
target phony.
