### PR TITLE
progressive-loading-api: Progressively return API result while built

### DIFF
--- a/languagelearning/settings.py
+++ b/languagelearning/settings.py
@@ -159,6 +159,9 @@ LOGGING = {
 # Path to scraper instructions.
 INSTRUCTIONS_DIR = spath('instructions')
 
+# Progressive responses
+PROGRESSIVE_RESPONSE_SEPARATOR = '=====[PROGRESSIVE_RESPONSE_END]====='
+
 # Use local settings, if any.
 try:
     from local_settings import *

--- a/search/views/search.py
+++ b/search/views/search.py
@@ -34,7 +34,7 @@ class SearchAPIView(APIView):
         if not self.expression or not self.words:
             raise ErrorResponse(u"'expression' can't be empty")
 
-    def get(self, request):
+    def progressive_get(self, request):
         self.fetch_parameters(request)
         if not self.query_types:
             raise ErrorResponse(u'No query type specified')
@@ -45,15 +45,15 @@ class SearchAPIView(APIView):
         for query_type in (u'translation', u'images', u'definitions'):
             if query_type in self.query_types:
                 results[query_type] = getattr(self, u'query_{0}'.format(query_type))() 
+                yield {
+                        u'expression': self.expression,
+                        u'source': self.source,
+                        u'target': self.target,
+                        u'status': u'success',
+                        u'results': results
+                    }
 
-        return self.render_to_response({
-                u'expression': self.expression,
-                u'source': self.source,
-                u'target': self.target,
-                u'status': u'success',
-                u'results': results
-            })
-    
+
     def handle_error(self, request, e):
         return self.render_to_response({
                 u'expression': self.expression,

--- a/search/views/search.py
+++ b/search/views/search.py
@@ -45,6 +45,10 @@ class SearchAPIView(APIView):
         for query_type in (u'translation', u'images', u'definitions'):
             if query_type in self.query_types:
                 results[query_type] = getattr(self, u'query_{0}'.format(query_type))() 
+                # TODO remove me: this can be uncommented to visually test
+                # progressive loading in different browsers.
+                # import time
+                # time.sleep(1)
                 yield {
                         u'expression': self.expression,
                         u'source': self.source,

--- a/static/js/adapters/search.js
+++ b/static/js/adapters/search.js
@@ -26,7 +26,8 @@ define([
     }
 
     /**
-     * Obtains promise that will contain an expression model when resolved.
+     * Obtains promise that will contain an expression model when resolved,
+     * and partial expression models as progress.
      * @param {String} expression The expression to be translated.
      * @returns {jQuery.Promise}
      */
@@ -62,6 +63,7 @@ define([
                 dataType: 'json',
                 url: '/api/v1/search?' +
                     $.param({
+                        progressive: true,
                         //key: '',
                         expression: expression,
                         //source: '',  // TODO
@@ -71,7 +73,10 @@ define([
                             'images',
                             'definitions'
                         ]
-                    }, true)
+                    }, true),
+                progress: function (content) {
+                    $dfd.notify(new ExpressionModel(content));
+                }
             }).success(function (content, status, jqXHR) {
                 addToCache(expression, content);
                 $dfd.resolve(new ExpressionModel(content));

--- a/static/js/languagelearning.main.js
+++ b/static/js/languagelearning.main.js
@@ -56,7 +56,8 @@ requirejs([
     'backbone',
     'json2',
     'tracekit',
-    'routers/languagelearning'
+    'routers/languagelearning',
+    'utils/ajaxStreaming'
 ], function ($, _, backbone, json, tracekit, LanguageLearningRouter) {
     "use strict";
 

--- a/static/js/routers/languagelearning.js
+++ b/static/js/routers/languagelearning.js
@@ -50,7 +50,11 @@ define([
             this._expressionView.$el.appendTo($mainDiv.show());
             loadingDfd = this._expressionView.loading();
 
-            searchAdapter.search(expression).done(function (expressionModel) {
+            searchAdapter.search(expression).progress(function (expressionModel) {
+                // TODO make it clear to user that loading is still in
+                // progress, without partially obstructing the view.
+                self._expressionView.render(expressionModel);
+            }).done(function (expressionModel) {
                 self._expressionView.render(expressionModel);
             }).fail(function (expressionModel) {
                 self._expressionView.render(expressionModel);

--- a/static/js/utils/ajaxStreaming.js
+++ b/static/js/utils/ajaxStreaming.js
@@ -1,0 +1,72 @@
+/*jslint browser: true, nomen: true */
+/*globals define, DEBUG_MODE*/
+
+define([
+    'jquery',
+    'json2'
+], function ($, json) {
+    "use strict";
+
+    // TODO read begin/splitters from headers.
+    var getResponse = function (content) {
+        var split = content
+            .replace(new RegExp('=+\\[PROGRESSIVE_RESPONSE_BEGIN\\]=+'), '')
+            .split(new RegExp('=+\\[PROGRESSIVE_RESPONSE_END\\]=+'));
+        return split[split.length - 2];
+    };
+
+    // Adapted from http://jsfiddle.net/tBTW2/
+    // and http://stackoverflow.com/questions/6035987/can-i-use-jquery-prefilters-to-detect-onReadyStateChange-events-where-readystate
+    $.ajaxPrefilter(function (options, _, jqXHR) {
+        if (options.progress) {
+            var xhrFactory = options.xhr;
+            options.dataFilter = function (rawResponse) {
+                return getResponse(rawResponse);
+            };
+            options.xhr = function () {
+                var xhr = xhrFactory.apply(this, arguments);
+                function loopWhileLoading() {
+                    if (!options._interval) {
+                        options._interval = setInterval(function () {
+                            // Update progress when length of response text
+                            // changes.
+                            var len = xhr.responseText.length,
+                                resp;
+                            if (options._lastResponseTextLength !== len) {
+                                options._lastResponseTextLength = len;
+                                resp = getResponse(xhr.responseText);
+                                if (resp) {
+                                    options.progress(json.parse(resp));
+                                }
+                            }
+                        }, 100);
+                    }
+                }
+                function terminateLoop() {
+                    clearInterval(options._interval);
+                }
+                function handleLoadStates() {
+                    if (xhr.readyState === 3) {
+                        loopWhileLoading();
+                    } else if (xhr.readyState === 4) {
+                        terminateLoop();
+                    }
+                }
+                if (xhr.addEventListener) {
+                    xhr.addEventListener("readystatechange", handleLoadStates, false);
+                } else {
+                    setTimeout(function () {
+                        var internal = xhr.onReadyStateChange;
+                        if (internal) {
+                            xhr.onReadyStateChange = function () {
+                                handleLoadStates();
+                                internal.apply(this, arguments);
+                            };
+                        }
+                    }, 0);
+                }
+                return xhr;
+            };
+        }
+    });
+});

--- a/static/test/adapters/search.test.js
+++ b/static/test/adapters/search.test.js
@@ -1,58 +1,60 @@
-/*jslint */
-/*globals beforeEach, describe, it, sinon*/
+/*jslint nomen:true*/
+/*globals beforeEach, describe, it, sinon, define, afterEach*/
 define([
-   'underscore',
-   'jquery',
-   'adapters/search',
-   'models/expression',
-   'expect',
-   'mocha',
-   'sinon'
+    'underscore',
+    'jquery',
+    'adapters/search',
+    'models/expression',
+    'expect',
+    'mocha',
+    'sinon'
 ], function (_, $, searchAdapter, ExpressionModel, expect) {
+    "use strict";
 
     describe("Search API", function () {
 
         var server;
 
-        before(function () {
+        beforeEach(function () {
             server = sinon.fakeServer.create();
         });
 
-        after(function () {
+        afterEach(function () {
             server.restore();
         });
 
         it("provides a translation for an expression", function (done) {
 
-            var searchExpression = 'bom dia';
+            var searchExpression = 'bom dia',
+                resp = {
+                    "expression": "bom dia",
+                    "results": {
+                        "translation": "good day"
+                    },
+                    "source": "pt",
+                    "status": "success",
+                    "target": "en"
+                };
 
             server.respondWith("GET", /\/api\/v1\/search/,
                                [200, { "Content-Type": "application/json" },
-                                   JSON.stringify({
-                                       "expression": "bom dia",
-                                       "results": {
-                                           "translation": "good day"
-                                       },
-                                       "source": "pt",
-                                       "status": "success",
-                                       "target": "en"
-                                   })
+                                   JSON.stringify(resp)
                                ]);
 
             searchAdapter.search(searchExpression)
                 .done(function (expression) {
-                expect(expression).to.be.an(ExpressionModel);
-                expect(expression.get('expression')).to.equal(searchExpression);
-                expect(expression.get('source')).to.equal('pt');
-                expect(expression.get('target')).to.equal('en');
+                    expect(expression).to.be.an(ExpressionModel);
+                    expect(expression.get('expression')).to.equal(searchExpression);
+                    expect(expression.get('source')).to.equal('pt');
+                    expect(expression.get('target')).to.equal('en');
 
-                var results = expression.get('results');
-                expect(results.translation).to.equal('good day');
-                done();
+                    var results = expression.get('results');
+                    expect(results.translation).to.equal('good day');
+                    done();
 
-                // TODO: Check for images results after merging pending changes
-                // to this test
-            });
+                    // TODO: Check for images results after merging pending changes
+                    // to this test
+                });
 
             server.respond();
         });

--- a/static/test/languagelearning.test.js
+++ b/static/test/languagelearning.test.js
@@ -1,78 +1,81 @@
 /*jslint browser:true*/
-/*globals mochaPhantomJS, mocha, DEBUG_MODE:true*/
+/*globals mochaPhantomJS, mocha, DEBUG_MODE:true, requirejs*/
 
 DEBUG_MODE = true;
 
-requirejs.config({
-
-    baseUrl: '../js',
-
-    paths: {
-        'models': 'models',
-        'collections': 'collections',
-        'views': 'views',
-        'templates': '../templates',
-        'backbone': 'vendor/backbone',
-        'jquery': 'vendor/jquery-1.9.1',
-        'json2': 'vendor/json2',
-        'mustache': 'vendor/mustache',
-        'text': 'vendor/text',
-        'underscore': 'vendor/underscore',
-        'test': '../test',
-        'fixtures': '../test/fixtures',
-        'expect': '../test/vendor/expect',
-        'mocha': '../test/vendor/mocha',
-        'sinon': '../test/vendor/sinon'
-    },
-
-    shim: {
-        'backbone': {
-            deps: ['underscore', 'jquery'],
-            exports: 'Backbone'
-        },
-        'json2': {
-            exports: 'JSON'
-        },
-        'jquery': {
-            exports: 'jQuery'
-        },
-        'mustache': {
-            exports: 'Mustache'
-        },
-        'underscore': {
-            exports: '_'
-        },
-        'expect': {
-            exports: 'expect'
-        },
-        'sinon': {
-            exports: 'sinon'
-        },
-        'mocha': {
-            exports: 'mocha',
-            init: function() {
-                this.mocha.ui('bdd');
-                this.mocha.checkLeaks();
-                this.mocha.globals(['jQuery*']);
-            }
-        }
-    },
-
-    modules: [
-        {
-            name: "languagelearning.test"
-        }
-    ]
-});
-
-requirejs([
-    'test/adapters/search.test'
-], function () {
+(function () {
     "use strict";
 
-    if (window.mochaPhantomJS) {
-        mochaPhantomJS.run();
-    } else {
-        mocha.run();
-    }
-});
+    requirejs.config({
+
+        baseUrl: '../js',
+
+        paths: {
+            'models': 'models',
+            'collections': 'collections',
+            'views': 'views',
+            'templates': '../templates',
+            'backbone': 'vendor/backbone',
+            'jquery': 'vendor/jquery-1.9.1',
+            'json2': 'vendor/json2',
+            'mustache': 'vendor/mustache',
+            'text': 'vendor/text',
+            'underscore': 'vendor/underscore',
+            'test': '../test',
+            'fixtures': '../test/fixtures',
+            'expect': '../test/vendor/expect',
+            'mocha': '../test/vendor/mocha',
+            'sinon': '../test/vendor/sinon'
+        },
+
+        shim: {
+            'backbone': {
+                deps: ['underscore', 'jquery'],
+                exports: 'Backbone'
+            },
+            'json2': {
+                exports: 'JSON'
+            },
+            'jquery': {
+                exports: 'jQuery'
+            },
+            'mustache': {
+                exports: 'Mustache'
+            },
+            'underscore': {
+                exports: '_'
+            },
+            'expect': {
+                exports: 'expect'
+            },
+            'sinon': {
+                exports: 'sinon'
+            },
+            'mocha': {
+                exports: 'mocha',
+                init: function () {
+                    this.mocha.ui('bdd');
+                    this.mocha.checkLeaks();
+                    this.mocha.globals(['jQuery*']);
+                }
+            }
+        },
+
+        modules: [
+            {
+                name: "languagelearning.test"
+            }
+        ]
+    });
+
+    requirejs([
+        'test/adapters/search.test',
+        'test/utils/ajaxStreaming.test'
+    ], function () {
+        if (window.mochaPhantomJS) {
+            mochaPhantomJS.run();
+        } else {
+            mocha.run();
+        }
+    });
+}());

--- a/static/test/utils/ajaxStreaming.test.js
+++ b/static/test/utils/ajaxStreaming.test.js
@@ -1,0 +1,100 @@
+/*jslint nomen:true*/
+/*globals beforeEach, describe, it, sinon, define, afterEach*/
+define([
+    'underscore',
+    'jquery',
+    'expect',
+    'mocha',
+    'sinon',
+    'utils/ajaxStreaming'
+], function (_, $, expect) {
+    "use strict";
+
+    describe("Progressive loading", function () {
+
+        var xhr, requests, jqXHR, req, progressSpy, clock,
+            sep = '===foobarbaz===',
+            headers = {
+                'X-Progressive-Response-Separator': sep,
+                'Content-Type': 'application/json'
+            };
+
+        beforeEach(function () {
+            requests = [];
+            xhr = sinon.useFakeXMLHttpRequest();
+
+            xhr.onCreate = function (xhr) {
+                requests.push(xhr);
+            };
+
+            progressSpy = sinon.spy();
+            jqXHR = $.ajax({
+                url: 'progressive-loading',
+                progress: progressSpy
+            });
+            req = requests[0];
+
+            clock = sinon.useFakeTimers();
+        });
+
+        afterEach(function () {
+            xhr.restore();
+            clock.restore();
+        });
+
+        describe("as the content is being sent", function () {
+
+            beforeEach(function () {
+                req.status = 200;
+                req.statusText = 'OK';
+                req.setResponseHeaders(headers);
+                req.responseText = req.responseBody = 'foo' + sep;
+                req.readyStateChange(3);
+            });
+
+            it("calls the progress callback", function () {
+                clock.tick(200);
+                expect(progressSpy.calledOnce).to.be(true);
+            });
+
+            it("does not call the progress callback if the content hasn't changed", function () {
+                clock.tick(200);
+                expect(progressSpy.calledOnce).to.be(true);
+                req.responseText = req.responseBody = req.responseText;
+                clock.tick(200);
+                expect(progressSpy.calledOnce).to.be(true);
+            });
+
+            it("calls the progress callback again when the content changes", function () {
+                clock.tick(200);
+                req.responseText = req.responseBody = req.responseText;
+                clock.tick(200);
+                expect(progressSpy.calledOnce).to.be(true);
+                req.responseText = req.responseBody = req.responseText + 'foo bar' + sep;
+                clock.tick(200);
+                expect(progressSpy.calledTwice).to.be(true);
+                expect(progressSpy.calledWith('foo bar')).to.equal(true);
+            });
+
+            it("reads the splitter from the 'X-Progressive-Response-Separator'", function () {
+                clock.tick(200);
+                expect(progressSpy.calledWith('foo')).to.equal(true);
+            });
+        });
+
+        describe("after the content is finished being sent", function () {
+            var content = ["foo", "bar", "baz"];
+
+            beforeEach(function () {
+                req.respond(200, headers, ['["foo"]', '["foo","bar"]', JSON.stringify(content), ''].join(sep));
+            });
+
+            it("reads the splitter from the 'X-Progressive-Response-Separator'", function (done) {
+                jqXHR.done(function (content) {
+                    expect(content).to.eql(content);
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/static/test/vendor/sinon.js
+++ b/static/test/vendor/sinon.js
@@ -1,5 +1,5 @@
 /**
- * Sinon.JS 1.6.0, 2013/02/18
+ * Sinon.JS 1.7.1, 2013/05/07
  *
  * @author Christian Johansen (christian@cjohansen.no)
  * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
@@ -33,9 +33,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-var sinon = (function () {
-"use strict";
-
+this.sinon = (function () {
 var buster = (function (setTimeout, B) {
     var isNode = typeof require == "function" && typeof module == "object";
     var div = typeof document != "undefined" && document.createElement("div");
@@ -505,6 +503,10 @@ var sinon = (function (buster) {
         }
     }
 
+    function isRestorable (obj) {
+        return typeof obj === "function" && typeof obj.restore === "function" && obj.restore.sinon;
+    }
+
     var sinon = {
         wrapMethod: function wrapMethod(object, property, method) {
             if (!object) {
@@ -631,11 +633,7 @@ var sinon = (function (buster) {
                 bLength += 1;
             }
 
-            if (aLength != bLength) {
-                return false;
-            }
-
-            return true;
+            return aLength == bLength;
         },
 
         functionName: function functionName(func) {
@@ -755,6 +753,19 @@ var sinon = (function (buster) {
                 throw new TypeError("The constructor should be a function.");
             }
             return sinon.stub(sinon.create(constructor.prototype));
+        },
+
+        restore: function (object) {
+            if (object !== null && typeof object === "object") {
+                for (var prop in object) {
+                    if (isRestorable(object[prop])) {
+                        object[prop].restore();
+                    }
+                }
+            }
+            else if (isRestorable(object)) {
+                object.restore();
+            }
         }
     };
 
@@ -766,6 +777,7 @@ var sinon = (function (buster) {
         } catch (e) {}
         module.exports = sinon;
         module.exports.spy = require("./sinon/spy");
+        module.exports.spyCall = require("./sinon/call");
         module.exports.stub = require("./sinon/stub");
         module.exports.mock = require("./sinon/mock");
         module.exports.collection = require("./sinon/collection");
@@ -1044,6 +1056,209 @@ var sinon = (function (buster) {
 /*jslint eqeqeq: false, onevar: false, plusplus: false*/
 /*global module, require, sinon*/
 /**
+  * Spy calls
+  *
+  * @author Christian Johansen (christian@cjohansen.no)
+  * @author Maximilian Antoni (mail@maxantoni.de)
+  * @license BSD
+  *
+  * Copyright (c) 2010-2013 Christian Johansen
+  * Copyright (c) 2013 Maximilian Antoni
+  */
+
+(function (sinon) {
+    var commonJSModule = typeof module == "object" && typeof require == "function";
+    if (!sinon && commonJSModule) {
+        sinon = require("../sinon");
+    }
+
+    if (!sinon) {
+        return;
+    }
+
+    function throwYieldError(proxy, text, args) {
+        var msg = sinon.functionName(proxy) + text;
+        if (args.length) {
+            msg += " Received [" + slice.call(args).join(", ") + "]";
+        }
+        throw new Error(msg);
+    }
+
+    var slice = Array.prototype.slice;
+
+    var callProto = {
+        calledOn: function calledOn(thisValue) {
+            if (sinon.match && sinon.match.isMatcher(thisValue)) {
+                return thisValue.test(this.thisValue);
+            }
+            return this.thisValue === thisValue;
+        },
+
+        calledWith: function calledWith() {
+            for (var i = 0, l = arguments.length; i < l; i += 1) {
+                if (!sinon.deepEqual(arguments[i], this.args[i])) {
+                    return false;
+                }
+            }
+
+            return true;
+        },
+
+        calledWithMatch: function calledWithMatch() {
+            for (var i = 0, l = arguments.length; i < l; i += 1) {
+                var actual = this.args[i];
+                var expectation = arguments[i];
+                if (!sinon.match || !sinon.match(expectation).test(actual)) {
+                    return false;
+                }
+            }
+            return true;
+        },
+
+        calledWithExactly: function calledWithExactly() {
+            return arguments.length == this.args.length &&
+                this.calledWith.apply(this, arguments);
+        },
+
+        notCalledWith: function notCalledWith() {
+            return !this.calledWith.apply(this, arguments);
+        },
+
+        notCalledWithMatch: function notCalledWithMatch() {
+            return !this.calledWithMatch.apply(this, arguments);
+        },
+
+        returned: function returned(value) {
+            return sinon.deepEqual(value, this.returnValue);
+        },
+
+        threw: function threw(error) {
+            if (typeof error === "undefined" || !this.exception) {
+                return !!this.exception;
+            }
+
+            return this.exception === error || this.exception.name === error;
+        },
+
+        calledWithNew: function calledWithNew(thisValue) {
+            return this.thisValue instanceof this.proxy;
+        },
+
+        calledBefore: function (other) {
+            return this.callId < other.callId;
+        },
+
+        calledAfter: function (other) {
+            return this.callId > other.callId;
+        },
+
+        callArg: function (pos) {
+            this.args[pos]();
+        },
+
+        callArgOn: function (pos, thisValue) {
+            this.args[pos].apply(thisValue);
+        },
+
+        callArgWith: function (pos) {
+            this.callArgOnWith.apply(this, [pos, null].concat(slice.call(arguments, 1)));
+        },
+
+        callArgOnWith: function (pos, thisValue) {
+            var args = slice.call(arguments, 2);
+            this.args[pos].apply(thisValue, args);
+        },
+
+        "yield": function () {
+            this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
+        },
+
+        yieldOn: function (thisValue) {
+            var args = this.args;
+            for (var i = 0, l = args.length; i < l; ++i) {
+                if (typeof args[i] === "function") {
+                    args[i].apply(thisValue, slice.call(arguments, 1));
+                    return;
+                }
+            }
+            throwYieldError(this.proxy, " cannot yield since no callback was passed.", args);
+        },
+
+        yieldTo: function (prop) {
+            this.yieldToOn.apply(this, [prop, null].concat(slice.call(arguments, 1)));
+        },
+
+        yieldToOn: function (prop, thisValue) {
+            var args = this.args;
+            for (var i = 0, l = args.length; i < l; ++i) {
+                if (args[i] && typeof args[i][prop] === "function") {
+                    args[i][prop].apply(thisValue, slice.call(arguments, 2));
+                    return;
+                }
+            }
+            throwYieldError(this.proxy, " cannot yield to '" + prop +
+                "' since no callback was passed.", args);
+        },
+
+        toString: function () {
+            var callStr = this.proxy.toString() + "(";
+            var args = [];
+
+            for (var i = 0, l = this.args.length; i < l; ++i) {
+                args.push(sinon.format(this.args[i]));
+            }
+
+            callStr = callStr + args.join(", ") + ")";
+
+            if (typeof this.returnValue != "undefined") {
+                callStr += " => " + sinon.format(this.returnValue);
+            }
+
+            if (this.exception) {
+                callStr += " !" + this.exception.name;
+
+                if (this.exception.message) {
+                    callStr += "(" + this.exception.message + ")";
+                }
+            }
+
+            return callStr;
+        }
+    };
+
+    callProto.invokeCallback = callProto.yield;
+
+    function createSpyCall(spy, thisValue, args, returnValue, exception, id) {
+        if (typeof id !== "number") {
+            throw new TypeError("Call id is not a number");
+        }
+        var proxyCall = sinon.create(callProto);
+        proxyCall.proxy = spy;
+        proxyCall.thisValue = thisValue;
+        proxyCall.args = args;
+        proxyCall.returnValue = returnValue;
+        proxyCall.exception = exception;
+        proxyCall.callId = id;
+
+        return proxyCall;
+    };
+    createSpyCall.toString = callProto.toString; // used by mocks
+
+    if (commonJSModule) {
+        module.exports = createSpyCall;
+    } else {
+        sinon.spyCall = createSpyCall;
+    }
+}(typeof sinon == "object" && sinon || null));
+
+
+/**
+  * @depend ../sinon.js
+  * @depend call.js
+  */
+/*jslint eqeqeq: false, onevar: false, plusplus: false*/
+/*global module, require, sinon*/
+/**
   * Spy functions
   *
   * @author Christian Johansen (christian@cjohansen.no)
@@ -1054,10 +1269,9 @@ var sinon = (function (buster) {
 
 (function (sinon) {
     var commonJSModule = typeof module == "object" && typeof require == "function";
-    var spyCall;
-    var callId = 0;
-    var push = [].push;
+    var push = Array.prototype.push;
     var slice = Array.prototype.slice;
+    var callId = 0;
 
     if (!sinon && commonJSModule) {
         sinon = require("../sinon");
@@ -1080,523 +1294,347 @@ var sinon = (function (buster) {
         return sinon.wrapMethod(object, property, spy.create(method));
     }
 
-    sinon.extend(spy, (function () {
+    function matchingFake(fakes, args, strict) {
+        if (!fakes) {
+            return;
+        }
 
-        function delegateToCalls(api, method, matchAny, actual, notCalled) {
-            api[method] = function () {
-                if (!this.called) {
-                    if (notCalled) {
-                        return notCalled.apply(this, arguments);
-                    }
-                    return false;
-                }
+        var alen = args.length;
 
-                var currentCall;
-                var matches = 0;
+        for (var i = 0, l = fakes.length; i < l; i++) {
+            if (fakes[i].matches(args, strict)) {
+                return fakes[i];
+            }
+        }
+    }
 
-                for (var i = 0, l = this.callCount; i < l; i += 1) {
-                    currentCall = this.getCall(i);
+    function incrementCallCount() {
+        this.called = true;
+        this.callCount += 1;
+        this.notCalled = false;
+        this.calledOnce = this.callCount == 1;
+        this.calledTwice = this.callCount == 2;
+        this.calledThrice = this.callCount == 3;
+    }
 
-                    if (currentCall[actual || method].apply(currentCall, arguments)) {
-                        matches += 1;
+    function createCallProperties() {
+        this.firstCall = this.getCall(0);
+        this.secondCall = this.getCall(1);
+        this.thirdCall = this.getCall(2);
+        this.lastCall = this.getCall(this.callCount - 1);
+    }
 
-                        if (matchAny) {
-                            return true;
-                        }
-                    }
-                }
-
-                return matches === this.callCount;
+    var vars = "a,b,c,d,e,f,g,h,i,j,k,l";
+    function createProxy(func) {
+        // Retain the function length:
+        var p;
+        if (func.length) {
+            eval("p = (function proxy(" + vars.substring(0, func.length * 2 - 1) +
+                ") { return p.invoke(func, this, slice.call(arguments)); });");
+        }
+        else {
+            p = function proxy() {
+                return p.invoke(func, this, slice.call(arguments));
             };
         }
+        return p;
+    }
 
-        function matchingFake(fakes, args, strict) {
-            if (!fakes) {
-                return;
-            }
+    var uuid = 0;
 
-            var alen = args.length;
-
-            for (var i = 0, l = fakes.length; i < l; i++) {
-                if (fakes[i].matches(args, strict)) {
-                    return fakes[i];
+    // Public API
+    var spyApi = {
+        reset: function () {
+            this.called = false;
+            this.notCalled = true;
+            this.calledOnce = false;
+            this.calledTwice = false;
+            this.calledThrice = false;
+            this.callCount = 0;
+            this.firstCall = null;
+            this.secondCall = null;
+            this.thirdCall = null;
+            this.lastCall = null;
+            this.args = [];
+            this.returnValues = [];
+            this.thisValues = [];
+            this.exceptions = [];
+            this.callIds = [];
+            if (this.fakes) {
+                for (var i = 0; i < this.fakes.length; i++) {
+                    this.fakes[i].reset();
                 }
             }
-        }
+        },
 
-        function incrementCallCount() {
-            this.called = true;
-            this.callCount += 1;
-            this.notCalled = false;
-            this.calledOnce = this.callCount == 1;
-            this.calledTwice = this.callCount == 2;
-            this.calledThrice = this.callCount == 3;
-        }
+        create: function create(func) {
+            var name;
 
-        function createCallProperties() {
-            this.firstCall = this.getCall(0);
-            this.secondCall = this.getCall(1);
-            this.thirdCall = this.getCall(2);
-            this.lastCall = this.getCall(this.callCount - 1);
-        }
-
-        var vars = "a,b,c,d,e,f,g,h,i,j,k,l";
-        function createProxy(func) {
-            // Retain the function length:
-            var p;
-            if (func.length) {
-                eval("p = (function proxy(" + vars.substring(0, func.length * 2 - 1) +
-                    ") { return p.invoke(func, this, slice.call(arguments)); });");
+            if (typeof func != "function") {
+                func = function () { };
+            } else {
+                name = sinon.functionName(func);
             }
-            else {
-                p = function proxy() {
-                    return p.invoke(func, this, slice.call(arguments));
-                };
-            }
-            return p;
-        }
 
-        var uuid = 0;
+            var proxy = createProxy(func);
 
-        // Public API
-        var spyApi = {
-            reset: function () {
-                this.called = false;
-                this.notCalled = true;
-                this.calledOnce = false;
-                this.calledTwice = false;
-                this.calledThrice = false;
-                this.callCount = 0;
-                this.firstCall = null;
-                this.secondCall = null;
-                this.thirdCall = null;
-                this.lastCall = null;
-                this.args = [];
-                this.returnValues = [];
-                this.thisValues = [];
-                this.exceptions = [];
-                this.callIds = [];
-                if (this.fakes) {
-                    for (var i = 0; i < this.fakes.length; i++) {
-                        this.fakes[i].reset();
-                    }
-                }
-            },
+            sinon.extend(proxy, spy);
+            delete proxy.create;
+            sinon.extend(proxy, func);
 
-            create: function create(func) {
-                var name;
+            proxy.reset();
+            proxy.prototype = func.prototype;
+            proxy.displayName = name || "spy";
+            proxy.toString = sinon.functionToString;
+            proxy._create = sinon.spy.create;
+            proxy.id = "spy#" + uuid++;
 
-                if (typeof func != "function") {
-                    func = function () { };
+            return proxy;
+        },
+
+        invoke: function invoke(func, thisValue, args) {
+            var matching = matchingFake(this.fakes, args);
+            var exception, returnValue;
+
+            incrementCallCount.call(this);
+            push.call(this.thisValues, thisValue);
+            push.call(this.args, args);
+            push.call(this.callIds, callId++);
+
+            try {
+                if (matching) {
+                    returnValue = matching.invoke(func, thisValue, args);
                 } else {
-                    name = sinon.functionName(func);
+                    returnValue = (this.func || func).apply(thisValue, args);
                 }
-
-                var proxy = createProxy(func);
-
-                sinon.extend(proxy, spy);
-                delete proxy.create;
-                sinon.extend(proxy, func);
-
-                proxy.reset();
-                proxy.prototype = func.prototype;
-                proxy.displayName = name || "spy";
-                proxy.toString = sinon.functionToString;
-                proxy._create = sinon.spy.create;
-                proxy.id = "spy#" + uuid++;
-
-                return proxy;
-            },
-
-            invoke: function invoke(func, thisValue, args) {
-                var matching = matchingFake(this.fakes, args);
-                var exception, returnValue;
-
-                incrementCallCount.call(this);
-                push.call(this.thisValues, thisValue);
-                push.call(this.args, args);
-                push.call(this.callIds, callId++);
-
-                try {
-                    if (matching) {
-                        returnValue = matching.invoke(func, thisValue, args);
-                    } else {
-                        returnValue = (this.func || func).apply(thisValue, args);
-                    }
-                } catch (e) {
-                    push.call(this.returnValues, undefined);
-                    exception = e;
-                    throw e;
-                } finally {
-                    push.call(this.exceptions, exception);
-                }
-
-                push.call(this.returnValues, returnValue);
-
-                createCallProperties.call(this);
-
-                return returnValue;
-            },
-
-            getCall: function getCall(i) {
-                if (i < 0 || i >= this.callCount) {
-                    return null;
-                }
-
-                return spyCall.create(this, this.thisValues[i], this.args[i],
-                                        this.returnValues[i], this.exceptions[i],
-                                        this.callIds[i]);
-            },
-
-            calledBefore: function calledBefore(spyFn) {
-                if (!this.called) {
-                    return false;
-                }
-
-                if (!spyFn.called) {
-                    return true;
-                }
-
-                return this.callIds[0] < spyFn.callIds[spyFn.callIds.length - 1];
-            },
-
-            calledAfter: function calledAfter(spyFn) {
-                if (!this.called || !spyFn.called) {
-                    return false;
-                }
-
-                return this.callIds[this.callCount - 1] > spyFn.callIds[spyFn.callCount - 1];
-            },
-
-            withArgs: function () {
-                var args = slice.call(arguments);
-
-                if (this.fakes) {
-                    var match = matchingFake(this.fakes, args, true);
-
-                    if (match) {
-                        return match;
-                    }
-                } else {
-                    this.fakes = [];
-                }
-
-                var original = this;
-                var fake = this._create();
-                fake.matchingAguments = args;
-                push.call(this.fakes, fake);
-
-                fake.withArgs = function () {
-                    return original.withArgs.apply(original, arguments);
-                };
-
-                for (var i = 0; i < this.args.length; i++) {
-                    if (fake.matches(this.args[i])) {
-                        incrementCallCount.call(fake);
-                        push.call(fake.thisValues, this.thisValues[i]);
-                        push.call(fake.args, this.args[i]);
-                        push.call(fake.returnValues, this.returnValues[i]);
-                        push.call(fake.exceptions, this.exceptions[i]);
-                        push.call(fake.callIds, this.callIds[i]);
-                    }
-                }
-                createCallProperties.call(fake);
-
-                return fake;
-            },
-
-            matches: function (args, strict) {
-                var margs = this.matchingAguments;
-
-                if (margs.length <= args.length &&
-                    sinon.deepEqual(margs, args.slice(0, margs.length))) {
-                    return !strict || margs.length == args.length;
-                }
-            },
-
-            printf: function (format) {
-                var spy = this;
-                var args = slice.call(arguments, 1);
-                var formatter;
-
-                return (format || "").replace(/%(.)/g, function (match, specifyer) {
-                    formatter = spyApi.formatters[specifyer];
-
-                    if (typeof formatter == "function") {
-                        return formatter.call(null, spy, args);
-                    } else if (!isNaN(parseInt(specifyer), 10)) {
-                        return sinon.format(args[specifyer - 1]);
-                    }
-
-                    return "%" + specifyer;
-                });
+            } catch (e) {
+                push.call(this.returnValues, undefined);
+                exception = e;
+                throw e;
+            } finally {
+                push.call(this.exceptions, exception);
             }
-        };
 
-        delegateToCalls(spyApi, "calledOn", true);
-        delegateToCalls(spyApi, "alwaysCalledOn", false, "calledOn");
-        delegateToCalls(spyApi, "calledWith", true);
-        delegateToCalls(spyApi, "calledWithMatch", true);
-        delegateToCalls(spyApi, "alwaysCalledWith", false, "calledWith");
-        delegateToCalls(spyApi, "alwaysCalledWithMatch", false, "calledWithMatch");
-        delegateToCalls(spyApi, "calledWithExactly", true);
-        delegateToCalls(spyApi, "alwaysCalledWithExactly", false, "calledWithExactly");
-        delegateToCalls(spyApi, "neverCalledWith", false, "notCalledWith",
-            function () { return true; });
-        delegateToCalls(spyApi, "neverCalledWithMatch", false, "notCalledWithMatch",
-            function () { return true; });
-        delegateToCalls(spyApi, "threw", true);
-        delegateToCalls(spyApi, "alwaysThrew", false, "threw");
-        delegateToCalls(spyApi, "returned", true);
-        delegateToCalls(spyApi, "alwaysReturned", false, "returned");
-        delegateToCalls(spyApi, "calledWithNew", true);
-        delegateToCalls(spyApi, "alwaysCalledWithNew", false, "calledWithNew");
-        delegateToCalls(spyApi, "callArg", false, "callArgWith", function () {
-            throw new Error(this.toString() + " cannot call arg since it was not yet invoked.");
-        });
-        spyApi.callArgWith = spyApi.callArg;
-        delegateToCalls(spyApi, "callArgOn", false, "callArgOnWith", function () {
-            throw new Error(this.toString() + " cannot call arg since it was not yet invoked.");
-        });
-        spyApi.callArgOnWith = spyApi.callArgOn;
-        delegateToCalls(spyApi, "yield", false, "yield", function () {
-            throw new Error(this.toString() + " cannot yield since it was not yet invoked.");
-        });
-        // "invokeCallback" is an alias for "yield" since "yield" is invalid in strict mode.
-        spyApi.invokeCallback = spyApi.yield;
-        delegateToCalls(spyApi, "yieldOn", false, "yieldOn", function () {
-            throw new Error(this.toString() + " cannot yield since it was not yet invoked.");
-        });
-        delegateToCalls(spyApi, "yieldTo", false, "yieldTo", function (property) {
-            throw new Error(this.toString() + " cannot yield to '" + property +
-                "' since it was not yet invoked.");
-        });
-        delegateToCalls(spyApi, "yieldToOn", false, "yieldToOn", function (property) {
-            throw new Error(this.toString() + " cannot yield to '" + property +
-                "' since it was not yet invoked.");
-        });
+            push.call(this.returnValues, returnValue);
 
-        spyApi.formatters = {
-            "c": function (spy) {
-                return sinon.timesInWords(spy.callCount);
-            },
+            createCallProperties.call(this);
 
-            "n": function (spy) {
-                return spy.toString();
-            },
+            return returnValue;
+        },
 
-            "C": function (spy) {
-                var calls = [];
-
-                for (var i = 0, l = spy.callCount; i < l; ++i) {
-                    var stringifiedCall = "    " + spy.getCall(i).toString();
-                    if (/\n/.test(calls[i - 1])) {
-                        stringifiedCall = "\n" + stringifiedCall;
-                    }
-                    push.call(calls, stringifiedCall);
-                }
-
-                return calls.length > 0 ? "\n" + calls.join("\n") : "";
-            },
-
-            "t": function (spy) {
-                var objects = [];
-
-                for (var i = 0, l = spy.callCount; i < l; ++i) {
-                    push.call(objects, sinon.format(spy.thisValues[i]));
-                }
-
-                return objects.join(", ");
-            },
-
-            "*": function (spy, args) {
-                var formatted = [];
-
-                for (var i = 0, l = args.length; i < l; ++i) {
-                    push.call(formatted, sinon.format(args[i]));
-                }
-
-                return formatted.join(", ");
+        getCall: function getCall(i) {
+            if (i < 0 || i >= this.callCount) {
+                return null;
             }
-        };
 
-        return spyApi;
-    }()));
+            return sinon.spyCall(this, this.thisValues[i], this.args[i],
+                                    this.returnValues[i], this.exceptions[i],
+                                    this.callIds[i]);
+        },
 
-    spyCall = (function () {
-
-        function throwYieldError(proxy, text, args) {
-            var msg = sinon.functionName(proxy) + text;
-            if (args.length) {
-                msg += " Received [" + slice.call(args).join(", ") + "]";
+        calledBefore: function calledBefore(spyFn) {
+            if (!this.called) {
+                return false;
             }
-            throw new Error(msg);
+
+            if (!spyFn.called) {
+                return true;
+            }
+
+            return this.callIds[0] < spyFn.callIds[spyFn.callIds.length - 1];
+        },
+
+        calledAfter: function calledAfter(spyFn) {
+            if (!this.called || !spyFn.called) {
+                return false;
+            }
+
+            return this.callIds[this.callCount - 1] > spyFn.callIds[spyFn.callCount - 1];
+        },
+
+        withArgs: function () {
+            var args = slice.call(arguments);
+
+            if (this.fakes) {
+                var match = matchingFake(this.fakes, args, true);
+
+                if (match) {
+                    return match;
+                }
+            } else {
+                this.fakes = [];
+            }
+
+            var original = this;
+            var fake = this._create();
+            fake.matchingAguments = args;
+            push.call(this.fakes, fake);
+
+            fake.withArgs = function () {
+                return original.withArgs.apply(original, arguments);
+            };
+
+            for (var i = 0; i < this.args.length; i++) {
+                if (fake.matches(this.args[i])) {
+                    incrementCallCount.call(fake);
+                    push.call(fake.thisValues, this.thisValues[i]);
+                    push.call(fake.args, this.args[i]);
+                    push.call(fake.returnValues, this.returnValues[i]);
+                    push.call(fake.exceptions, this.exceptions[i]);
+                    push.call(fake.callIds, this.callIds[i]);
+                }
+            }
+            createCallProperties.call(fake);
+
+            return fake;
+        },
+
+        matches: function (args, strict) {
+            var margs = this.matchingAguments;
+
+            if (margs.length <= args.length &&
+                sinon.deepEqual(margs, args.slice(0, margs.length))) {
+                return !strict || margs.length == args.length;
+            }
+        },
+
+        printf: function (format) {
+            var spy = this;
+            var args = slice.call(arguments, 1);
+            var formatter;
+
+            return (format || "").replace(/%(.)/g, function (match, specifyer) {
+                formatter = spyApi.formatters[specifyer];
+
+                if (typeof formatter == "function") {
+                    return formatter.call(null, spy, args);
+                } else if (!isNaN(parseInt(specifyer), 10)) {
+                    return sinon.format(args[specifyer - 1]);
+                }
+
+                return "%" + specifyer;
+            });
         }
+    };
 
-        var callApi = {
-            create: function create(spy, thisValue, args, returnValue, exception, id) {
-                var proxyCall = sinon.create(spyCall);
-                delete proxyCall.create;
-                proxyCall.proxy = spy;
-                proxyCall.thisValue = thisValue;
-                proxyCall.args = args;
-                proxyCall.returnValue = returnValue;
-                proxyCall.exception = exception;
-                proxyCall.callId = typeof id == "number" && id || callId++;
-
-                return proxyCall;
-            },
-
-            calledOn: function calledOn(thisValue) {
-                if (sinon.match && sinon.match.isMatcher(thisValue)) {
-                    return thisValue.test(this.thisValue);
+    function delegateToCalls(method, matchAny, actual, notCalled) {
+        spyApi[method] = function () {
+            if (!this.called) {
+                if (notCalled) {
+                    return notCalled.apply(this, arguments);
                 }
-                return this.thisValue === thisValue;
-            },
-
-            calledWith: function calledWith() {
-                for (var i = 0, l = arguments.length; i < l; i += 1) {
-                    if (!sinon.deepEqual(arguments[i], this.args[i])) {
-                        return false;
-                    }
-                }
-
-                return true;
-            },
-
-            calledWithMatch: function calledWithMatch() {
-                for (var i = 0, l = arguments.length; i < l; i += 1) {
-                    var actual = this.args[i];
-                    var expectation = arguments[i];
-                    if (!sinon.match || !sinon.match(expectation).test(actual)) {
-                        return false;
-                    }
-                }
-                return true;
-            },
-
-            calledWithExactly: function calledWithExactly() {
-                return arguments.length == this.args.length &&
-                    this.calledWith.apply(this, arguments);
-            },
-
-            notCalledWith: function notCalledWith() {
-                return !this.calledWith.apply(this, arguments);
-            },
-
-            notCalledWithMatch: function notCalledWithMatch() {
-                return !this.calledWithMatch.apply(this, arguments);
-            },
-
-            returned: function returned(value) {
-                return sinon.deepEqual(value, this.returnValue);
-            },
-
-            threw: function threw(error) {
-                if (typeof error == "undefined" || !this.exception) {
-                    return !!this.exception;
-                }
-
-                if (typeof error == "string") {
-                    return this.exception.name == error;
-                }
-
-                return this.exception === error;
-            },
-
-            calledWithNew: function calledWithNew(thisValue) {
-                return this.thisValue instanceof this.proxy;
-            },
-
-            calledBefore: function (other) {
-                return this.callId < other.callId;
-            },
-
-            calledAfter: function (other) {
-                return this.callId > other.callId;
-            },
-
-            callArg: function (pos) {
-                this.args[pos]();
-            },
-
-            callArgOn: function (pos, thisValue) {
-                this.args[pos].apply(thisValue);
-            },
-
-            callArgWith: function (pos) {
-                this.callArgOnWith.apply(this, [pos, null].concat(slice.call(arguments, 1)));
-            },
-
-            callArgOnWith: function (pos, thisValue) {
-                var args = slice.call(arguments, 2);
-                this.args[pos].apply(thisValue, args);
-            },
-
-            "yield": function () {
-                this.yieldOn.apply(this, [null].concat(slice.call(arguments, 0)));
-            },
-
-            yieldOn: function (thisValue) {
-                var args = this.args;
-                for (var i = 0, l = args.length; i < l; ++i) {
-                    if (typeof args[i] === "function") {
-                        args[i].apply(thisValue, slice.call(arguments, 1));
-                        return;
-                    }
-                }
-                throwYieldError(this.proxy, " cannot yield since no callback was passed.", args);
-            },
-
-            yieldTo: function (prop) {
-                this.yieldToOn.apply(this, [prop, null].concat(slice.call(arguments, 1)));
-            },
-
-            yieldToOn: function (prop, thisValue) {
-                var args = this.args;
-                for (var i = 0, l = args.length; i < l; ++i) {
-                    if (args[i] && typeof args[i][prop] === "function") {
-                        args[i][prop].apply(thisValue, slice.call(arguments, 2));
-                        return;
-                    }
-                }
-                throwYieldError(this.proxy, " cannot yield to '" + prop +
-                    "' since no callback was passed.", args);
-            },
-
-            toString: function () {
-                var callStr = this.proxy.toString() + "(";
-                var args = [];
-
-                for (var i = 0, l = this.args.length; i < l; ++i) {
-                    push.call(args, sinon.format(this.args[i]));
-                }
-
-                callStr = callStr + args.join(", ") + ")";
-
-                if (typeof this.returnValue != "undefined") {
-                    callStr += " => " + sinon.format(this.returnValue);
-                }
-
-                if (this.exception) {
-                    callStr += " !" + this.exception.name;
-
-                    if (this.exception.message) {
-                        callStr += "(" + this.exception.message + ")";
-                    }
-                }
-
-                return callStr;
+                return false;
             }
+
+            var currentCall;
+            var matches = 0;
+
+            for (var i = 0, l = this.callCount; i < l; i += 1) {
+                currentCall = this.getCall(i);
+
+                if (currentCall[actual || method].apply(currentCall, arguments)) {
+                    matches += 1;
+
+                    if (matchAny) {
+                        return true;
+                    }
+                }
+            }
+
+            return matches === this.callCount;
         };
-        callApi.invokeCallback = callApi.yield;
-        return callApi;
-    }());
+    }
 
-    spy.spyCall = spyCall;
+    delegateToCalls("calledOn", true);
+    delegateToCalls("alwaysCalledOn", false, "calledOn");
+    delegateToCalls("calledWith", true);
+    delegateToCalls("calledWithMatch", true);
+    delegateToCalls("alwaysCalledWith", false, "calledWith");
+    delegateToCalls("alwaysCalledWithMatch", false, "calledWithMatch");
+    delegateToCalls("calledWithExactly", true);
+    delegateToCalls("alwaysCalledWithExactly", false, "calledWithExactly");
+    delegateToCalls("neverCalledWith", false, "notCalledWith",
+        function () { return true; });
+    delegateToCalls("neverCalledWithMatch", false, "notCalledWithMatch",
+        function () { return true; });
+    delegateToCalls("threw", true);
+    delegateToCalls("alwaysThrew", false, "threw");
+    delegateToCalls("returned", true);
+    delegateToCalls("alwaysReturned", false, "returned");
+    delegateToCalls("calledWithNew", true);
+    delegateToCalls("alwaysCalledWithNew", false, "calledWithNew");
+    delegateToCalls("callArg", false, "callArgWith", function () {
+        throw new Error(this.toString() + " cannot call arg since it was not yet invoked.");
+    });
+    spyApi.callArgWith = spyApi.callArg;
+    delegateToCalls("callArgOn", false, "callArgOnWith", function () {
+        throw new Error(this.toString() + " cannot call arg since it was not yet invoked.");
+    });
+    spyApi.callArgOnWith = spyApi.callArgOn;
+    delegateToCalls("yield", false, "yield", function () {
+        throw new Error(this.toString() + " cannot yield since it was not yet invoked.");
+    });
+    // "invokeCallback" is an alias for "yield" since "yield" is invalid in strict mode.
+    spyApi.invokeCallback = spyApi.yield;
+    delegateToCalls("yieldOn", false, "yieldOn", function () {
+        throw new Error(this.toString() + " cannot yield since it was not yet invoked.");
+    });
+    delegateToCalls("yieldTo", false, "yieldTo", function (property) {
+        throw new Error(this.toString() + " cannot yield to '" + property +
+            "' since it was not yet invoked.");
+    });
+    delegateToCalls("yieldToOn", false, "yieldToOn", function (property) {
+        throw new Error(this.toString() + " cannot yield to '" + property +
+            "' since it was not yet invoked.");
+    });
 
-    // This steps outside the module sandbox and will be removed
-    sinon.spyCall = spyCall;
+    spyApi.formatters = {
+        "c": function (spy) {
+            return sinon.timesInWords(spy.callCount);
+        },
+
+        "n": function (spy) {
+            return spy.toString();
+        },
+
+        "C": function (spy) {
+            var calls = [];
+
+            for (var i = 0, l = spy.callCount; i < l; ++i) {
+                var stringifiedCall = "    " + spy.getCall(i).toString();
+                if (/\n/.test(calls[i - 1])) {
+                    stringifiedCall = "\n" + stringifiedCall;
+                }
+                push.call(calls, stringifiedCall);
+            }
+
+            return calls.length > 0 ? "\n" + calls.join("\n") : "";
+        },
+
+        "t": function (spy) {
+            var objects = [];
+
+            for (var i = 0, l = spy.callCount; i < l; ++i) {
+                push.call(objects, sinon.format(spy.thisValues[i]));
+            }
+
+            return objects.join(", ");
+        },
+
+        "*": function (spy, args) {
+            var formatted = [];
+
+            for (var i = 0, l = args.length; i < l; ++i) {
+                push.call(formatted, sinon.format(args[i]));
+            }
+
+            return formatted.join(", ");
+        }
+    };
+
+    sinon.extend(spy, spyApi);
+
+    spy.spyCall = sinon.spyCall;
 
     if (commonJSModule) {
         module.exports = spy;
@@ -2926,15 +2964,16 @@ if (typeof sinon == "undefined") {
 (function () {
     var push = [].push;
 
-    sinon.Event = function Event(type, bubbles, cancelable) {
-        this.initEvent(type, bubbles, cancelable);
+    sinon.Event = function Event(type, bubbles, cancelable, target) {
+        this.initEvent(type, bubbles, cancelable, target);
     };
 
     sinon.Event.prototype = {
-        initEvent: function(type, bubbles, cancelable) {
+        initEvent: function(type, bubbles, cancelable, target) {
             this.type = type;
             this.bubbles = bubbles;
             this.cancelable = cancelable;
+            this.target = target;
         },
 
         stopPropagation: function () {},
@@ -3037,6 +3076,18 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
         this.requestBody = null;
         this.status = 0;
         this.statusText = "";
+
+        var xhr = this;
+
+        ["loadstart", "load", "abort", "loadend"].forEach(function (eventName) {
+            xhr.addEventListener(eventName, function (event) {
+                var listener = xhr["on" + eventName];
+
+                if (listener && typeof listener == "function") {
+                    listener(event);
+                }
+            });
+        });
 
         if (typeof FakeXMLHttpRequest.onCreate == "function") {
             FakeXMLHttpRequest.onCreate(this);
@@ -3191,6 +3242,13 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
             }
 
             this.dispatchEvent(new sinon.Event("readystatechange"));
+
+            switch (this.readyState) {
+                case FakeXMLHttpRequest.DONE:
+                    this.dispatchEvent(new sinon.Event("load", false, false, this));
+                    this.dispatchEvent(new sinon.Event("loadend", false, false, this));
+                    break;
+            }
         },
 
         setRequestHeader: function setRequestHeader(header, value) {
@@ -3246,6 +3304,8 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
             if (typeof this.onSend == "function") {
                 this.onSend(this);
             }
+
+            this.dispatchEvent(new sinon.Event("loadstart", false, false, this));
         },
 
         abort: function abort() {
@@ -3260,6 +3320,11 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
             }
 
             this.readyState = sinon.FakeXMLHttpRequest.UNSENT;
+
+            this.dispatchEvent(new sinon.Event("abort", false, false, this));
+            if (typeof this.onerror === "function") {
+                this.onerror();
+            }
         },
 
         getResponseHeader: function getResponseHeader(header) {
@@ -3340,6 +3405,10 @@ sinon.xhr = { XMLHttpRequest: this.XMLHttpRequest };
             this.status = typeof status == "number" ? status : 200;
             this.statusText = FakeXMLHttpRequest.statusCodes[this.status];
             this.setResponseBody(body || "");
+            if (typeof this.onload === "function"){
+                this.onload();
+            }
+            
         }
     });
 
@@ -4149,7 +4218,14 @@ if (typeof module == "object" && typeof require == "function") {
             if (!sinon.calledInOrder(arguments)) {
                 try {
                     expected = [].join.call(arguments, ", ");
-                    actual = sinon.orderByFirstCall(slice.call(arguments)).join(", ");
+                    var calls = slice.call(arguments);
+                    var i = calls.length;
+                    while (i) {
+                        if (!calls[--i].called) {
+                            calls.splice(i, 1);
+                        }
+                    }
+                    actual = sinon.orderByFirstCall(calls).join(", ");
                 } catch (e) {
                     // If this fails, we'll just fall back to the blank string
                 }
@@ -4218,6 +4294,6 @@ if (typeof module == "object" && typeof require == "function") {
     } else {
         sinon.assert = assert;
     }
-}(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : global));
+}(typeof sinon == "object" && sinon || null, typeof window != "undefined" ? window : (typeof self != "undefined") ? self : global));
 
 return sinon;}.call(typeof window != 'undefined' && window || {}));

--- a/utils/api.py
+++ b/utils/api.py
@@ -82,6 +82,9 @@ class APIView(JSONResponseMixin, View):
         return self.render_to_response(context)
     
     def handle_progressive(self, progressive_handler, request):
+        # TODO the PROGRESSIVE_RESPONSE_BEGIN could be removed: if you
+        # uncomment the time.sleep(1) in `search/views/search.py:51`, the
+        # progressive loading is unaffected in FF either way.
         yield u'{separators}[PROGRESSIVE_RESPONSE_BEGIN]{separators}\n'.format(separators=u'='*500)
         for progressive_context in progressive_handler(request):
             yield self.render_to_response(progressive_context, progressive=True)

--- a/utils/api.py
+++ b/utils/api.py
@@ -4,6 +4,7 @@
 import logging
 
 from django.conf import settings
+from django.http import HttpResponse
 from django.views.generic.base import View
 
 from utils.json import JSONResponseMixin
@@ -35,7 +36,7 @@ class APIView(JSONResponseMixin, View):
     """
     def dispatch(self, request, *args, **kwargs):
         try:
-            return super(APIView, self).dispatch(request, *args, **kwargs)
+            return self.progressive_dispatch(request, *args, **kwargs)
         except ErrorResponse as e:
             return self.handle_error(request, e)
         except Exception as e:
@@ -47,4 +48,41 @@ class APIView(JSONResponseMixin, View):
                 logger.exception(e)
                 return self.handle_error(request, e)
 
+    def progressive_dispatch(self, request, *args, **kwargs):
+        """
+        Uses special self.progressive_<httpverb>() methods when defined, otherwise 
+        use the normal self.<httpverb>() method
+
+        When defined, the progressive version is expected to return a generator, which 
+        will be used to generate *both* the progressive response and the continuous
+        one. It should yield values progressively as the response context is being 
+        generated.
+        """
+        if request.method.lower() not in self.http_method_names:
+            return self.http_method_not_allowed(request, *args, **kwargs)
+        progressive_handler = getattr(self, 'progressive_{0}'.format(request.method.lower()))
+        progressive_requested = request.REQUEST.get('progressive')
+
+        if progressive_handler:
+            if progressive_requested:
+                return HttpResponse(self.handle_progressive(progressive_handler, request), 
+                                    content_type='application/json')
+            else:
+                return self.handle_noprogressive(progressive_handler, request)
+        else:
+            if progressive_requested:
+                return self.http_method_not_allowed(request, *args, **kwargs)
+            else:
+                return super(APIView, self).dispatch(request, *args, **kwargs)
+
+    def handle_noprogressive(self, progressive_handler, request):
+        context = {}
+        for progressive_context in progressive_handler(request):
+            context = progressive_context
+        return self.render_to_response(context)
+    
+    def handle_progressive(self, progressive_handler, request):
+        yield u'{separators}[PROGRESSIVE_RESPONSE_BEGIN]{separators}\n'.format(separators=u'='*500)
+        for progressive_context in progressive_handler(request):
+            yield self.render_to_response(progressive_context, progressive=True)
 

--- a/utils/json.py
+++ b/utils/json.py
@@ -8,11 +8,15 @@ from django.utils import simplejson as json
 # View Mixins #######################################################
 
 class JSONResponseMixin(object):
-    def render_to_response(self, context, **httpresponse_kwargs):
+    def render_to_response(self, context, progressive=False, **httpresponse_kwargs):
         """Returns a JSON response containing 'context' as payload"""
 
-        return self.get_json_response(self.convert_context_to_json(context), 
-                                      **httpresponse_kwargs)
+        if progressive:
+            return u'{content}\n{separators}[PROGRESSIVE_RESPONSE_END]{separators}\n'\
+                    .format(content=self.convert_context_to_json(context), separators=u'='*5)
+        else:
+            return self.get_json_response(self.convert_context_to_json(context), 
+                                          **httpresponse_kwargs)
 
     def get_json_response(self, content, **httpresponse_kwargs):
         """Construct an `HttpResponse` object."""

--- a/utils/json.py
+++ b/utils/json.py
@@ -2,6 +2,7 @@
 # Imports ###########################################################
 
 from django import http
+from django.conf import settings
 from django.utils import simplejson as json
 
 
@@ -12,8 +13,9 @@ class JSONResponseMixin(object):
         """Returns a JSON response containing 'context' as payload"""
 
         if progressive:
-            return u'{content}\n{separators}[PROGRESSIVE_RESPONSE_END]{separators}\n'\
-                    .format(content=self.convert_context_to_json(context), separators=u'='*5)
+            return u'{content}\n{separator}\n'\
+                    .format(content=self.convert_context_to_json(context), 
+                            separator=settings.PROGRESSIVE_RESPONSE_SEPARATOR)
         else:
             return self.get_json_response(self.convert_context_to_json(context), 
                                           **httpresponse_kwargs)


### PR DESCRIPTION
First draft implementation, for experimentation.

Add `&progressive=1` at the end of an existing API query, and it will return the results progressively as they become available, instead of everything at once at the end.

There are three parts on which I'd specifically like to have comments before finalizing this:
- The `PROGRESSIVE_RESPONSE_BEGIN` tag string is currently very long, as in Firefox I only see the content being displayed progressively after a certain amount of data has been sent by the server - it is thus voluntarily long to allow to see the data displayed live in the browser while testing. We might be able to get rid of this tag completely if the readyState is immediately fired by browsers (ie if this is just behavior when _displaying_ the data in the browser).
- Is the format of the separator good for you? We can change those, I don't particularly like the current format : )
- Currently the whole API response is resent every time - this allows to make things more generic, and even allow to modify information already sent in previous updates. Size is likely not an issue here, but if it makes things unpractical on the client side let me know.

Another aspect to be careful about before releasing this: the amount of caching that the reverse proxy (nginx currently) will be doing when forwarding the requests, and whether gzip compression has side effects here.
