### PR TITLE
no-prod-testing-load:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ build:
 	#   catching errors here.
 	${UGLIFYJS} -c -m -o static/build/js/vendor/require.js \
 	    static/build/js/vendor/require.js
+	#
+	# Remove any testing scripts.
+	#
+	rm -rf static/build/test
 
 update-nltk:
 	@echo Downloading corpus files for nltk library...

--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -46,22 +46,13 @@
       </footer>
     </div>
 
-    <!-- TODO test runner: this should not be included unless running tests. -->
-    <script src="/static/js/vendor/jquery-1.9.1.js"></script>
-    <script src="/static/test/vendor/expect.js"></script>
-    <script src="/static/test/vendor/mocha.js"></script>
-    <script src="/static/test/vendor/sinon.js" type="text/javascript"></script>
-    <script>mocha.setup('bdd')</script>
-    <script src="/static/test/index.test.js"></script>
     <script>
-      mocha.checkLeaks();
-      mocha.globals(['jQuery*', 'Backbone*']);
       if (window.mochaPhantomJS) {
-        mochaPhantomJS.run();
-      } else {
-        //mocha.run();
+        var body = document.getElementsByTagName('body')[0],
+            script = document.createElement('script');
+        script.src = "/static/test/languagelearning.test.bootstrap.js";
+        body.appendChild(script);
       }
     </script>
-    <!-- TODO end test runner -->
   </body>
 </html>

--- a/static/test/languagelearning.test.bootstrap.js
+++ b/static/test/languagelearning.test.bootstrap.js
@@ -1,0 +1,85 @@
+/*jslint browser:true plusplus:true*/
+/*globals mocha, mochaPhantomJS*/
+
+(function () {
+    "use strict";
+
+    var body = document.getElementsByTagName('body')[0],
+
+        loadedLibs = 0,
+
+        /**
+         * Add paths to any test-only libraries here.
+         */
+        libs = [
+            "/static/js/vendor/jquery-1.9.1.js",
+            "/static/test/vendor/expect.js",
+            "/static/test/vendor/mocha.js",
+            "/static/test/vendor/sinon.js",
+        ],
+
+        loadedTests = 0,
+
+        /**
+         * Add paths to any testing scripts here.
+         */
+        tests = [
+            "/static/test/index.test.js"
+        ],
+
+        /**
+         * This creates a script, appends it to the page, and watches it for
+         * loading purposes.
+         */
+        createScript = function (src) {
+            var script = document.createElement('script');
+            script.src = src;
+            body.appendChild(script);
+            return script;
+        },
+
+        /**
+         * This is fired every time a test is loaded, and starts mocha when
+         * all tests are loaded.
+         */
+        testLoaded = function () {
+            loadedTests += 1;
+            if (loadedTests === tests.length) {
+                mocha.checkLeaks();
+                mocha.globals(['jQuery*', 'Backbone*']);
+                mochaPhantomJS.run();
+            }
+        },
+
+        /**
+         * Load the tests.
+         */
+        loadTests = function () {
+            var i;
+            mocha.setup('bdd');
+            for (i = 0; i < tests.length; i += 1) {
+                createScript(tests[i]).onload = testLoaded;
+            }
+        },
+
+        /**
+         * This is fired every time a library is loaded, and finishes
+         * initialization when all scripts are loaded.
+         */
+        libLoaded = function () {
+            loadedLibs += 1;
+            if (loadedLibs === libs.length) {
+                loadTests();
+            }
+        };
+
+    /**
+     * Load all libraries in a loop.
+     */
+    (function () {
+        var i;
+        for (i = 0; i < libs.length; i += 1) {
+            createScript(libs[i]).onload = libLoaded;
+        }
+    }());
+}());


### PR DESCRIPTION
This patch moves browser-specific test loading to a separate module, which
allows us to exclude all test (and test library) loading in production.  This
should considerably reduce the weight of the application.

Also, the `Makefile` now deletes test files from the build results -- this
should hide our tests from prying end users.  They will still see the loading
stub, but all the actual test code will be gone.
