### PR TITLE
no-animation-tests:

### DIFF
--- a/static/js/languagelearning.main.js
+++ b/static/js/languagelearning.main.js
@@ -61,6 +61,12 @@ requirejs([
 ], function ($, _, backbone, json, tracekit, LanguageLearningRouter) {
     "use strict";
 
+    // TODO would be better to use fake timers and keep animations during
+    // testing, but recent jQuery/Sinon doesn't seem to cooperate.
+    if (window.mochaPhantomJS) {
+        $.fx.off = true;
+    }
+
     $(document).ready(function () {
         var router = new LanguageLearningRouter();
 

--- a/static/test/index.test.js
+++ b/static/test/index.test.js
@@ -17,17 +17,6 @@
 
     describe("The loaded index page", function () {
 
-        /**
-         * Set a document.ready callback after any others would have been set.
-         */
-        beforeEach(function (done) {
-            setTimeout(function () {
-                $(document).ready(function () {
-                    done();
-                });
-            }, 200);
-        });
-
         it("has no loading spinner", function () {
             expect($('.js-loading-spinner')).to.have.length(0);
             expect($('.js-loading-spinner * .base-loading-spinner')).to.have.length(0);
@@ -101,14 +90,11 @@
                 server.restore();
             });
 
-            it('should display a loading indicator', function (done) {
+            it('should display a loading indicator', function () {
                 var $loading = $('.base-loading');
                 expect($loading.length).to.equal(1);
-                setTimeout(function () {
-                    expect($loading.is(':visible')).to.be(true);
-                    expect(Number($loading.css('opacity'))).not.to.equal(0);
-                    done();
-                }, 400);
+                expect($loading.is(':visible')).to.be(true);
+                expect(Number($loading.css('opacity'))).not.to.equal(0);
             });
 
             it('should change the cursor to loading', function () {
@@ -299,12 +285,9 @@
                     server.respond();
                 });
 
-                it('should no longer display a loading indicator', function (done) {
-                    setTimeout(function () {
-                        var $loading = $('.base-loading');
-                        expect($loading.is(':visible')).to.be(false);
-                        done();
-                    }, 1000);
+                it('should no longer display a loading indicator', function () {
+                    var $loading = $('.base-loading');
+                    expect($loading.is(':visible')).to.be(false);
                 });
 
                 it('should change the cursor back to normal', function () {

--- a/static/test/languagelearning.test.bootstrap.js
+++ b/static/test/languagelearning.test.bootstrap.js
@@ -71,15 +71,21 @@
             if (loadedLibs === libs.length) {
                 loadTests();
             }
+        },
+
+        /**
+         * Loads all libraries in a loop.
+         */
+        loadLibs = function () {
+            var i;
+            for (i = 0; i < libs.length; i += 1) {
+                createScript(libs[i]).onload = libLoaded;
+            }
         };
 
-    /**
-     * Load all libraries in a loop.
-     */
-    (function () {
-        var i;
-        for (i = 0; i < libs.length; i += 1) {
-            createScript(libs[i]).onload = libLoaded;
-        }
-    }());
+    if (document.readyState === "complete") {
+        loadLibs();
+    } else {
+        window.addEventListener("load", loadLibs, false);
+    }
 }());


### PR DESCRIPTION
Turning off animations during testing, allowing them to run faster and more
reliably.

Ideally, we would use Sinon's fake timers to speed up jQuery's animations in
a controlled way, but recent jQuery seems to be bypassing Sinon's overwriting
of the global setInterval method.
